### PR TITLE
bugfix for toml version, bumping to 1.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amplify-stateless"
-version = "1.0.0"
+version = "1.2.1"
 description = "Microservice library for building stateless microservices"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Will need to publish a new release tag (v1.2.1) after this is merged.