### PR TITLE
Endpoint decorators

### DIFF
--- a/examples/string_appender_service/string_appender_service/processor.py
+++ b/examples/string_appender_service/string_appender_service/processor.py
@@ -1,10 +1,8 @@
 """Simple processor that appends two path parameters together."""
 
-from typing import List
-
 from pydantic import BaseModel, Field
 
-from stateless_microservice import BaseProcessor, StatelessAction
+from stateless_microservice import BaseProcessor, stateless_action
 
 
 class AppendPathParams(BaseModel):
@@ -27,23 +25,18 @@ class StringAppenderProcessor(BaseProcessor):
     def name(self) -> str:
         return "string-appender"
 
-    def get_stateless_actions(self) -> List[StatelessAction]:
-        return [
-            StatelessAction(
-                name="append_strings",
-                path="/append/{first}/{second}",
-                path_params_model=AppendPathParams,
-                response_model=AppendResponse,
-                handler=self.handle_append,
-                methods=("GET",),
-                summary="Append two path parameters together.",
-                description=(
-                    "Demonstrates path parameter usage by taking two strings from the URL path "
-                    "and returning them concatenated together."
-                ),
-            ),
-        ]
-
+    @stateless_action(
+        name="append_strings",
+        path="/append/{first}/{second}",
+        path_params_model=AppendPathParams,
+        response_model=AppendResponse,
+        methods=("GET",),
+        summary="Append two path parameters together.",
+        description=(
+            "Demonstrates path parameter usage by taking two strings from the URL path "
+            "and returning them concatenated together."
+        ),
+    )
     async def handle_append(self, path_params: AppendPathParams) -> AppendResponse:
         """Append the two path parameters and return the result."""
         result = path_params.first + path_params.second

--- a/stateless_microservice/__init__.py
+++ b/stateless_microservice/__init__.py
@@ -1,6 +1,6 @@
 """Stateless Microservice toolkit for synchronous FastAPI services."""
 
-from .processor import BaseProcessor, StatelessAction
+from .processor import BaseProcessor, StatelessAction, stateless_action
 from .api import create_app, ServiceConfig
 from .config import settings
 from .direct import fetch_s3_bytes, run_blocking, render_bytes
@@ -13,6 +13,7 @@ __version__ = "1.0.0"
 __all__ = [
     "BaseProcessor",
     "StatelessAction",
+    "stateless_action",
     "create_app",
     "ServiceConfig",
     "settings",

--- a/stateless_microservice/processor.py
+++ b/stateless_microservice/processor.py
@@ -1,5 +1,6 @@
 """Base processor interface for stateless (request/response) microservices."""
 
+import inspect
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, List
@@ -41,6 +42,70 @@ class StatelessAction:
     required_scopes: list[str] | None = None
 
 
+def stateless_action(
+    name: str,
+    path: str,
+    request_model: type[BaseModel] | None = None,
+    response_model: type[BaseModel] | None = None,
+    methods: tuple[str, ...] = ("POST",),
+    path_params_model: type[BaseModel] | None = None,
+    summary: str | None = None,
+    description: str | None = None,
+    tags: tuple[str, ...] | None = None,
+    media_type: str | None = None,
+    required_scopes: list[str] | None = None,
+):
+    """
+    Decorator to mark a method as a stateless action endpoint.
+
+    This decorator stores metadata on the method that will be automatically
+    discovered by BaseProcessor.get_stateless_actions().
+
+    Args:
+        name: Short identifier used for logging and OpenAPI docs.
+        path: FastAPI route path (e.g., "/transform").
+        request_model: Optional Pydantic model for request validation.
+        response_model: Optional Pydantic model for response serialization.
+        methods: HTTP methods to expose (defaults to POST).
+        path_params_model: Optional Pydantic model for path parameter validation.
+        summary: Optional OpenAPI summary.
+        description: Optional longer description.
+        tags: Optional OpenAPI tags.
+        media_type: Optional override for response media type.
+        required_scopes: Optional list of scopes required for authentication.
+
+    Example:
+        @stateless_action(
+            name="echo",
+            path="/echo",
+            request_model=EchoRequest,
+            response_model=EchoResponse,
+            summary="Echo a message"
+        )
+        async def echo_message(self, request: EchoRequest) -> EchoResponse:
+            return EchoResponse(message=request.message)
+    """
+
+    def decorator(func):
+        # Store metadata on the function
+        func._stateless_action_metadata = {
+            "name": name,
+            "path": path,
+            "request_model": request_model,
+            "response_model": response_model,
+            "methods": methods,
+            "path_params_model": path_params_model,
+            "summary": summary,
+            "description": description,
+            "tags": tags,
+            "media_type": media_type,
+            "required_scopes": required_scopes,
+        }
+        return func
+
+    return decorator
+
+
 class BaseProcessor(ABC):
     """Hook point for stateless microservices."""
 
@@ -58,6 +123,31 @@ class BaseProcessor(ABC):
         """
         Return the list of stateless actions provided by this processor.
 
-        Override in subclasses to expose synchronous microservice endpoints.
+        By default, this automatically discovers methods decorated with @stateless_action.
+        Subclasses can override this method to manually define actions or mix both approaches.
         """
-        return []
+        actions = []
+
+        # Auto-discover decorated methods
+        for name, method in inspect.getmembers(self, predicate=inspect.ismethod):
+            # Check if the method has action metadata
+            if hasattr(method, "_stateless_action_metadata"):
+                metadata = method._stateless_action_metadata
+                actions.append(
+                    StatelessAction(
+                        name=metadata["name"],
+                        path=metadata["path"],
+                        handler=method,
+                        request_model=metadata["request_model"],
+                        response_model=metadata["response_model"],
+                        methods=metadata["methods"],
+                        path_params_model=metadata["path_params_model"],
+                        summary=metadata["summary"],
+                        description=metadata["description"],
+                        tags=metadata["tags"],
+                        media_type=metadata["media_type"],
+                        required_scopes=metadata["required_scopes"],
+                    )
+                )
+
+        return actions

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,0 +1,194 @@
+"""Tests for the @stateless_action decorator."""
+
+import pytest
+from pydantic import BaseModel, Field
+
+from stateless_microservice import BaseProcessor, StatelessAction, stateless_action
+
+
+class SampleRequest(BaseModel):
+    """Sample request model."""
+
+    value: str = Field(..., description="Test value")
+
+
+class SampleResponse(BaseModel):
+    """Sample response model."""
+
+    result: str = Field(..., description="Test result")
+
+
+class DecoratorTestProcessor(BaseProcessor):
+    """Test processor using decorators."""
+
+    @property
+    def name(self) -> str:
+        return "decorator-test"
+
+    @stateless_action(
+        name="test_action",
+        path="/test",
+        request_model=SampleRequest,
+        response_model=SampleResponse,
+        methods=("POST",),
+        summary="Test action",
+        description="A test action for decorator verification",
+        required_scopes=["read"],
+    )
+    async def handle_test(self, request: SampleRequest) -> SampleResponse:
+        """Handle test request."""
+        return SampleResponse(result=f"Processed: {request.value}")
+
+    @stateless_action(
+        name="simple_action",
+        path="/simple",
+        methods=("GET",),
+        summary="Simple action",
+    )
+    def handle_simple(self) -> dict:
+        """Handle simple request with no models."""
+        return {"status": "ok"}
+
+
+def test_decorator_discovery():
+    """Test that decorated methods are auto-discovered."""
+    processor = DecoratorTestProcessor()
+    actions = processor.get_stateless_actions()
+
+    # Should find both decorated methods
+    assert len(actions) == 2
+
+    # Check that actions are StatelessAction instances
+    assert all(isinstance(action, StatelessAction) for action in actions)
+
+    # Find the test_action
+    test_action = next(a for a in actions if a.name == "test_action")
+    assert test_action.path == "/test"
+    assert test_action.request_model == SampleRequest
+    assert test_action.response_model == SampleResponse
+    assert test_action.methods == ("POST",)
+    assert test_action.summary == "Test action"
+    assert test_action.description == "A test action for decorator verification"
+    assert test_action.required_scopes == ["read"]
+
+    # Find the simple_action
+    simple_action = next(a for a in actions if a.name == "simple_action")
+    assert simple_action.path == "/simple"
+    assert simple_action.methods == ("GET",)
+    assert simple_action.summary == "Simple action"
+    assert simple_action.request_model is None
+    assert simple_action.response_model is None
+
+
+def test_decorator_handler_binding():
+    """Test that handlers are properly bound to the processor instance."""
+    processor = DecoratorTestProcessor()
+    actions = processor.get_stateless_actions()
+
+    test_action = next(a for a in actions if a.name == "test_action")
+
+    # The handler should be bound to the processor instance
+    assert test_action.handler.__self__ is processor
+
+
+@pytest.mark.asyncio
+async def test_decorator_handler_execution():
+    """Test that decorated handlers execute correctly."""
+    processor = DecoratorTestProcessor()
+    actions = processor.get_stateless_actions()
+
+    # Test the async handler
+    test_action = next(a for a in actions if a.name == "test_action")
+    request = SampleRequest(value="hello")
+    response = await test_action.handler(request)
+    assert isinstance(response, SampleResponse)
+    assert response.result == "Processed: hello"
+
+    # Test the sync handler
+    simple_action = next(a for a in actions if a.name == "simple_action")
+    response = simple_action.handler()
+    assert response == {"status": "ok"}
+
+
+class MixedProcessor(BaseProcessor):
+    """Test processor mixing decorators and manual actions."""
+
+    @property
+    def name(self) -> str:
+        return "mixed-test"
+
+    @stateless_action(
+        name="decorated_action",
+        path="/decorated",
+        methods=("GET",),
+    )
+    def decorated_method(self) -> dict:
+        """Decorated method."""
+        return {"type": "decorated"}
+
+    def manual_method(self) -> dict:
+        """Manual method (not decorated)."""
+        return {"type": "manual"}
+
+    def get_stateless_actions(self):
+        """Mix auto-discovered and manual actions."""
+        # Get auto-discovered actions
+        actions = super().get_stateless_actions()
+
+        # Add a manual action
+        actions.append(
+            StatelessAction(
+                name="manual_action",
+                path="/manual",
+                handler=self.manual_method,
+                methods=("GET",),
+            )
+        )
+
+        return actions
+
+
+def test_mixed_decorator_and_manual():
+    """Test that decorators and manual StatelessAction definitions can coexist."""
+    processor = MixedProcessor()
+    actions = processor.get_stateless_actions()
+
+    # Should find both the decorated and manual action
+    assert len(actions) == 2
+
+    action_names = {a.name for a in actions}
+    assert "decorated_action" in action_names
+    assert "manual_action" in action_names
+
+
+def test_backward_compatibility():
+    """Test that processors without decorators still work (backward compatibility)."""
+
+    class LegacyProcessor(BaseProcessor):
+        """Old-style processor without decorators."""
+
+        @property
+        def name(self) -> str:
+            return "legacy"
+
+        def get_stateless_actions(self):
+            """Manually define actions the old way."""
+            return [
+                StatelessAction(
+                    name="legacy_action",
+                    path="/legacy",
+                    handler=self.handle_legacy,
+                    methods=("POST",),
+                )
+            ]
+
+        def handle_legacy(self) -> dict:
+            """Handle legacy request."""
+            return {"status": "legacy"}
+
+    processor = LegacyProcessor()
+    actions = processor.get_stateless_actions()
+
+    assert len(actions) == 1
+    assert actions[0].name == "legacy_action"
+    assert actions[0].path == "/legacy"


### PR DESCRIPTION
Adds a decorator option for defining endpoints to simplify boilerplate around stateless actions.

The decorator attaches a metadata attribute to its respective handler function. When `get_stateless_actions` is called, it iterates through all of its methods, and checks if they have this metadata attribute. If they do, it logs them as a stateless action. Note that the handlers must be methods of the Processor instance. 

* Add `stateless_microservice` decorator to `stateless_microservice/processor.py`.
* Update `examples/string_appended_service` to use the decorator pattern.
* Add `tests/test_decorator.py` to confirm functionality.