### PR TITLE
add initial lifespan passthrough implementation

### DIFF
--- a/stateless_microservice/__init__.py
+++ b/stateless_microservice/__init__.py
@@ -1,7 +1,7 @@
 """Stateless Microservice toolkit for synchronous FastAPI services."""
 
 from .processor import BaseProcessor, StatelessAction
-from .api import create_app, ServiceConfig
+from .api import create_app, ServiceConfig, Lifespan
 from .config import settings
 from .direct import fetch_s3_bytes, run_blocking, render_bytes
 from .apache_conf import ApacheConfigParams, generate_apache_vhost_config
@@ -14,6 +14,7 @@ __all__ = [
     "StatelessAction",
     "create_app",
     "ServiceConfig",
+    "Lifespan",
     "settings",
     "fetch_s3_bytes",
     "run_blocking",

--- a/stateless_microservice/api.py
+++ b/stateless_microservice/api.py
@@ -3,7 +3,10 @@
 import inspect
 import logging
 import re
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from typing import Callable
 
 from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
@@ -11,6 +14,8 @@ from pydantic import BaseModel, ValidationError
 
 from .models import ErrorResponse, HealthResponse
 from .processor import BaseProcessor, StatelessAction
+
+Lifespan = Callable[[FastAPI], AsyncGenerator[None, None]]
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +39,8 @@ class ServiceConfig:
 def create_app(
     processor: BaseProcessor,
     config: ServiceConfig | None = None,
-    auth_client=None
+    auth_client=None,
+    lifespan: Lifespan | None = None,
 ) -> FastAPI:
     """
     Create a FastAPI application for a stateless processor.
@@ -43,6 +49,7 @@ def create_app(
         processor: The processor instance implementing business logic
         config: Optional service configuration
         auth_client: Optional AuthClient for token-based authentication
+        lifespan: Optional async context manager for startup/shutdown lifecycle
     """
 
     config = config or ServiceConfig()
@@ -60,6 +67,7 @@ def create_app(
         title=f"{service_name.title()} Stateless API",
         description=service_description,
         version=service_version,
+        lifespan=lifespan,
     )
 
     app.state.processor = processor

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -1,0 +1,61 @@
+"""Tests for lifespan passthrough in create_app."""
+
+from contextlib import asynccontextmanager
+from typing import List
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from stateless_microservice import BaseProcessor, StatelessAction, create_app
+
+
+class SimpleProcessor(BaseProcessor):
+    @property
+    def name(self) -> str:
+        return "test-lifespan"
+
+    def get_stateless_actions(self) -> List[StatelessAction]:
+        return [
+            StatelessAction(
+                name="check_state",
+                path="/check",
+                handler=self.check_state,
+                methods=("GET",),
+            ),
+        ]
+
+    def check_state(self):
+        return {"status": "ok"}
+
+
+def test_lifespan_startup_and_shutdown():
+    """Test that lifespan context manager is called on startup and shutdown."""
+    events = []
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        events.append("startup")
+        app.state.initialized = True
+        yield
+        events.append("shutdown")
+
+    processor = SimpleProcessor()
+    app = create_app(processor, lifespan=lifespan)
+
+    with TestClient(app) as client:
+        assert "startup" in events
+        assert app.state.initialized is True
+        response = client.get("/check")
+        assert response.status_code == 200
+
+    assert "shutdown" in events
+
+
+def test_no_lifespan_works():
+    """Test that create_app still works without lifespan."""
+    processor = SimpleProcessor()
+    app = create_app(processor)
+
+    with TestClient(app) as client:
+        response = client.get("/check")
+        assert response.status_code == 200


### PR DESCRIPTION
Adds the ability for users to define a FastAPI lifespan for their processor. The lifespan function is passed through the `create_app` function to FastAPI. 